### PR TITLE
Make youtube player responsive (adjusts to screen width)

### DIFF
--- a/_includes/youtubeplayer.html
+++ b/_includes/youtubeplayer.html
@@ -1,7 +1,6 @@
-
-<iframe src="https://www.youtube.com/embed/{{ include.id }}"
-    width="560"
-    height="315"
+<div class="youtubeplayer">
+  <iframe class="youtube-iframe" src="https://www.youtube.com/embed/{{ include.id }}"
     frameborder="0"
     allowfullscreen>
-</iframe>
+  </iframe>
+</div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -83,6 +83,20 @@ $a-tags-hover: 'a:active, a:hover';
     }
 }
 
+.youtubeplayer {
+    position: relative;
+    overflow: hidden;
+    padding-top: 56.25%;
+  }
+.youtube-iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 footer {
     text-align: center;
     #{$a-tags} {


### PR DESCRIPTION
This works nicely on phones and does not seem to break desktop  browsers either.

- Scales to full content width
- The only hardcoded thing is an expected 16:9 aspect ratio for the video container, but I think ours always are.