### PR TITLE
Wider screens fix

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -31,6 +31,17 @@ $nav-hover-color: lighten($nav-text-color, 50%);
 
 @import "{{ site.theme }}";
 
+/* make content wider on maximized browser on large screens */
+@media screen and (min-width: 1366px) {
+    .main-content {
+      max-width: 80rem;
+    }
+    .main-content table {
+        width: 100%;
+        display: table;
+    }
+  }
+
 body {
     background: #221427;
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
This is the same fix I did for Josh for container plumbing. 

Basically on a laptop with full HD screen people tend to keep their browser maximized, and the Cayman theme is a bit narrow, especially since we have bumped out font size a bit.

So this makes an additional "breakpoint" for layout for one notch wider browser so it makes it a bit wider, a compromise of keeping the content lines short enough to be still reasonably readable, but also allowing for more layout options like columns without cramming everything too narrow.